### PR TITLE
feat: log devtools shortcut registration

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,18 @@ npm install
 
 ## Development
 
+Use the start script, which builds the project and launches Electron in development
+mode:
+
 ```bash
 npm start
+```
+
+The `start` script sets `NODE_ENV=development`. When launching Electron
+manually, ensure the environment variable is set:
+
+```bash
+NODE_ENV=development electron .
 ```
 
 ## Build (AppImage + deb)

--- a/main.ts
+++ b/main.ts
@@ -33,12 +33,19 @@ function createWindow() {
   });
 
   if (isDev) {
-    globalShortcut.register('Control+Alt+D', () => {
+    const accelerator = 'Control+Alt+D';
+    const registered = globalShortcut.register(accelerator, () => {
       if (mainWindow) {
         mainWindow.setKiosk(false);
         mainWindow.webContents.openDevTools({ mode: 'detach' });
       }
     });
+
+    if (!registered) {
+      console.error(`Failed to register global shortcut ${accelerator}; it may already be in use.`);
+    } else {
+      console.log(`Registered global shortcut ${accelerator}`);
+    }
   }
 
   mainWindow.on('closed', () => {


### PR DESCRIPTION
## Summary
- document setting NODE_ENV when launching locally
- log devtools shortcut registration status and warn on conflicts

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c00584b870832e872d8e43beeef0da