### PR TITLE
feat: add runtime server toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,19 @@ manually, ensure the environment variable is set:
 NODE_ENV=development electron .
 ```
 
+## Configuration
+
+The app loads its URLs from environment variables:
+
+- `PROD_URL` – production primary server (defaults to `https://192.168.1.10/app/vocs/`)
+- `PROD_BACKUP_URL` – production backup server (defaults to the value of `PROD_URL`)
+- `TEST_URL` – test primary server (defaults to `https://192.168.1.11/app/vocs/`)
+- `TEST_BACKUP_URL` – test backup server (defaults to the value of `TEST_URL`)
+
+At runtime you can press the hidden shortcut <kbd>Ctrl</kbd>+<kbd>Alt</kbd>+<kbd>Shift</kbd>+<kbd>T</kbd> to toggle
+between the production and test servers. If a load fails, the app automatically
+falls back to the backup server for the current environment.
+
 ## Build (AppImage + deb)
 
 ```bash


### PR DESCRIPTION
## Summary
- support primary/backup servers for both production and test environments via env vars
- auto-fallback to backup on load failure and reset to primary when toggling environments
- document new server configuration and runtime toggle

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c13acb9bd8832e9afb60c33b18fded