### PR TITLE
Allow microphone and add devtools shortcut

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -1,4 +1,73 @@
-import { app, BrowserWindow } from 'electron';
+import { app, BrowserWindow, globalShortcut, session } from 'electron';
+
+type MicrophonePermissionDetails =
+  | Electron.MediaAccessPermissionRequest
+  | Electron.PermissionCheckHandlerHandlerDetails
+  | undefined;
+
+const isMicrophoneRequest = (details: MicrophonePermissionDetails): boolean => {
+  if (!details) {
+    return true;
+  }
+
+  if ('mediaTypes' in details && Array.isArray(details.mediaTypes)) {
+    return details.mediaTypes.some((type) => type === 'audio');
+  }
+
+  if ('mediaType' in details && typeof details.mediaType === 'string') {
+    return details.mediaType === 'audio';
+  }
+
+  return true;
+};
+
+const registerDevToolsShortcut = (): void => {
+  const accelerator = 'CommandOrControl+Shift+I';
+  const registered = globalShortcut.register(accelerator, () => {
+    const targetWindow = BrowserWindow.getFocusedWindow() ?? mainWindow;
+    const webContents = targetWindow?.webContents;
+
+    if (!webContents) {
+      return;
+    }
+
+    if (webContents.isDevToolsOpened()) {
+      webContents.closeDevTools();
+    } else {
+      webContents.openDevTools({ mode: 'detach' });
+    }
+  });
+
+  if (!registered) {
+    console.warn(`Failed to register shortcut: ${accelerator}`);
+  }
+};
+
+const configureMicrophonePermissions = (): void => {
+  const defaultSession = session.defaultSession;
+
+  if (!defaultSession) {
+    console.warn('No default session available to configure microphone permissions.');
+    return;
+  }
+
+  defaultSession.setPermissionRequestHandler((_, permission, callback, details) => {
+    if (permission === 'media' && isMicrophoneRequest(details)) {
+      callback(true);
+      return;
+    }
+
+    callback(false);
+  });
+
+  defaultSession.setPermissionCheckHandler((_, permission, _origin, details) => {
+    if (permission === 'media') {
+      return isMicrophoneRequest(details);
+    }
+
+    return false;
+  });
+};
 
 const APP_URL = process.env.APP_URL ?? 'https://10.0.0.10/app/vocs/';
 
@@ -29,7 +98,9 @@ const createWindow = async (): Promise<void> => {
 };
 
 app.whenReady().then(() => {
+  configureMicrophonePermissions();
   void createWindow();
+  registerDevToolsShortcut();
 
   app.on('activate', () => {
     if (BrowserWindow.getAllWindows().length === 0) {
@@ -47,4 +118,8 @@ app.on('window-all-closed', () => {
   if (process.platform !== 'darwin') {
     app.quit();
   }
+});
+
+app.on('will-quit', () => {
+  globalShortcut.unregisterAll();
 });


### PR DESCRIPTION
## Summary
- ensure the default session automatically grants microphone access requests
- add a global shortcut to toggle the devtools console
- clean up shortcut registration when the app quits

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ca4e68fbc0832e980ff83741266db1