### PR TITLE
Enable kiosk mode and update version

### DIFF
--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -11,3 +11,6 @@ linux:
     - deb
     - rpm
   icon: resources/icon.svg
+rpm:
+  depends:
+    - libXtst6

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openvocs-electron",
-  "version": "0.1.0",
+  "version": "0.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openvocs-electron",
-      "version": "0.1.0",
+      "version": "0.9.0",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^20.11.30",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openvocs-electron",
-  "version": "0.1.0",
+  "version": "0.9.0",
   "description": "Minimal Electron kiosk app for OpenVocs",
   "main": "dist/main.js",
   "author": {


### PR DESCRIPTION
## Summary
- enable Electron kiosk mode, hide the menu bar, and drop the temporary display overlay
- block modifier and function key shortcuts to avoid leaving the kiosk experience
- require libXtst6 for rpm builds and bump the app version to 0.9.0

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cab9cb20d8832e8bd7b73cf2e0064e